### PR TITLE
Fix for crash on version 1.197.180

### DIFF
--- a/Dev/SEToolbox/SEToolbox/Interop/ToolboxPlatform.cs
+++ b/Dev/SEToolbox/SEToolbox/Interop/ToolboxPlatform.cs
@@ -127,6 +127,19 @@ namespace SEToolbox.Interop
 
         (string Name, uint MaxClock, uint Cores) m_cpuInfo;
 
+        event Action IVRageSystem.OnResuming
+        {
+            add
+            {
+                throw new NotImplementedException();
+            }
+
+            remove
+            {
+                throw new NotImplementedException();
+            }
+        }
+
         public string GetAppDataPath()
         {
             throw new NotImplementedException();
@@ -239,6 +252,11 @@ namespace SEToolbox.Interop
         }
 
         public int? GetExperimentalPCULimit(int safePCULimit)
+        {
+            throw new NotImplementedException();
+        }
+
+        DateTime IVRageSystem.GetNetworkTimeUTC()
         {
             throw new NotImplementedException();
         }


### PR DESCRIPTION
The latest hot patch is causing a crash:

![image](https://user-images.githubusercontent.com/395128/110896255-139f6400-82b0-11eb-9dfb-febfeb4105fd.png)

Adding stub methods for this interface seems to solve the problem. 